### PR TITLE
downstream rollin, added inline styles to stylesheet, fixed linting

### DIFF
--- a/src/spice.html
+++ b/src/spice.html
@@ -1,0 +1,153 @@
+<html>
+<head>
+    <title>Spices : Cinnamon</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<div class="cs-jumbotron cs-jumbotron-small">
+    <div class="cs-header cs-flex-row cs-flex-center">
+        <div class="cs-header-logo cs-header-logo-inline cs-flex-row cs-flex-center">
+            <img src="/resources/cinnamon.svg" alt="">
+            <div>spices</div>
+        </div>
+        <div class="cs-header-menu">
+            <a class="cs-header-menu-link " href="/">Home</a>
+            <a class="cs-header-menu-link " href="/themes">Themes</a>
+            <a class="cs-header-menu-link active" href="/applets">Applets</a>
+            <a class="cs-header-menu-link " href="/desklets">Desklets</a>
+            <a class="cs-header-menu-link " href="/extensions">Extensions</a>
+            <!-- <a class="cs-header-menu-link cs-header-menu-login " href="/auth/login">Log In</a>
+                 <a class="cs-header-menu-signup cs-button cs-button-thin-text" href="/auth/register">Sign Up</a> -->
+        </div>
+    </div>
+</div>
+
+<div class="cs-main-wrap cs-flex-column cs-flex-grow">
+    <div class="cs-main-content">
+        <div class="cs-flex cs-details-head">
+            <div class="cs-flex cs-flex-grow cs-flex-wrap cs-flex-center">
+                <h1>Pomodoro Timer</h1>
+                <div>by gfreeau</div>
+            </div>
+            <div class="cs-flex cs-flex-center">
+                <a href="https://github.com/linuxmint/cinnamon-spices-applets/tree/master/pomodoro@gregfreeman.org" target='_blank' class='cs-button cs-details-head-button-w'>Website</a>&nbsp;
+                <a href="http://cinnamon-spices-master.linuxmint.com/files/applets/pomodoro@gregfreeman.org.zip" class='cs-button cs-details-head-button'>Download</a>
+            </div>
+        </div>
+        <div class="cs-details-body">
+            <div>
+                UUID: pomodoro@gregfreeman.org
+            </div>
+            <div>
+                Score: 37
+            </div>
+            <div>
+                Last edited: <span title="2017-03-14, 17:35">5 days ago</span>
+            </div>
+            <div>
+                Last commit: <a href="https://github.com/linuxmint/cinnamon-spices-applets/commits/master/pomodoro@gregfreeman.org">254eccb17263530220584421234761dba851fa21</a>
+            </div>
+            <br>
+            <a href="http://cinnamon-spices-master.linuxmint.com/git/applets/pomodoro@gregfreeman.org/screenshot.png">
+                <img src='http://cinnamon-spices-master.linuxmint.com/git/applets/pomodoro@gregfreeman.org/screenshot.png' class='cs-item-details-screenshot'/>
+            </a>
+            <div class="cs-item-details-description">
+                Great tool for boosted productivity!
+            </div>
+        </div>
+        <div class="cs-comment-box">
+            <h2 class="cs-comments-title">12 Comments</h2>
+                <div class="cs-media cs-comment-row cs-flex-row">
+                    <div class="cs-media-image">
+                        <img alt='' src='/resources/default_avatar.jpg' class='avatar avatar-50 photo'/>
+                    </div>
+                    <div class="cs-comment-body cs-flex-column cs-flex-grow">
+                        <div class="cs-media-content cs-comment-author cs-flex-row">
+                            <div class="cs-comment-name">
+                                <a href="http://cinnamon-spices-master.linuxmint.com/users/view/9843" class='url'>alLa</a>
+                            </div>
+                            -
+                            <div class="cs-comment-date" title='2015-11-30, 16:55'>
+                                1 year ago
+                            </div>
+                        </div>
+                        <div class="cs-comment-text">
+                            Thanks for this helpful applet!<br>
+                            <br>
+                            The way I use it is that I only use one &quot;pomodoro before long break&quot; - so that my screen gets &quot;blocked&quot; by the overlay. Then I manage the duration of the break myself.<br>
+                            <br>
+                            The advantages for me are: My screen really gets my attention to take a break (it is &quot;locked&quot; ;)) and I start the next pomodoro manually and therefore cannot miss its start (as many other users noted too).<br>
+                            <br>
+                            So the applet would be perfect for me if it had the option to &quot;block the screen&quot; also for the short breaks, and also start again manually after a short break...<br>
+                            <br>
+                            I know that I'm not really a pomodoro specialist, but it helps me to keep up my focus and is a great support for my tired eyes... Thank you very much!
+                        </div>
+                    </div>
+                </div>
+                <div class="cs-media cs-comment-row cs-flex-row">
+                    <div class="cs-media-image">
+                        <img alt='' src='/resources/default_avatar.jpg' class='avatar avatar-50 photo'/>
+                    </div>
+                    <div class="cs-media-content cs-comment-body cs-flex-column cs-flex-grow">
+                        <div class="cs-comment-author cs-flex-row">
+                            <div class="cs-comment-name">
+                                <a href="http://cinnamon-spices-master.linuxmint.com/users/view/8988" class='url'>uggh</a>
+                            </div>
+                            -
+                            <div class="cs-comment-date" title='2015-08-18, 11:44'>1 year ago</div>
+                        </div>
+                        <div class="cs-comment-text">
+                            I add my request to legion1978's to include a sound warning when the break is over. Please.
+                        </div>
+                    </div>
+                </div>
+                <div class="cs-media cs-comment-row cs-flex-row">
+                    <div class="cs-media-image">
+                        <img alt='' src='/resources/default_avatar.jpg' class='avatar avatar-50 photo'/>
+                    </div>
+                    <div class="cs-media-content cs-flex-column cs-flex-grow">
+                        <div class="cs-comment-author cs-flex-row">
+                            <div class="cs-comment-name">
+                                <a href="http://cinnamon-spices-master.linuxmint.com/users/view/8760" class='url'>mateusz</a>
+                            </div>
+                            -
+                            <div class="cs-comment-date" title='2015-07-26, 07:48'>1 year ago</div>
+                        </div>
+                        <div class="cs-comment-text">
+                            Good work! Please add new features to this applet from github page (issues) eg. auto start timer when you run the applet.
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <!-- END comments-box -->
+        </div>
+    </div>
+        <div class="cs-footer cs-footer-login-signup">
+            <div class="cs-footer-navigation">
+                <div class="cs-main-wrap cs-flex">
+                    <ul class="cs-footer-sub-navigation cs-inline-list">
+                        <li><a class="" href="/">Home</a></li>
+                        <li><a class="" href="/themes">Themes</a></li>
+                        <li><a class="active" href="/applets">Applets</a></li>
+                        <li><a class="" href="/desklets">Desklets</a></li>
+                        <li><a class="" href="/extensions">Extensions</a></li>
+                                            <!-- <li><a class="" href="/auth/login">Log In</a></li>
+                            <li><a  class="" href="/auth/register">Sign Up</a></li> -->
+                                    </ul>
+                    <ul class="cs-footer-sub-navigation cs-inline-list">
+                        <li><a href="http://developer.linuxmint.com/reference/git/cinnamon-tutorials/extension-system.html">Development</a></li>
+                        <li><a href="http://github.com/linuxmint">Github</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="cs-footer-copyright cs-main-wrap cs-flex">
+                <div class="cs-copyright">
+                </div>
+                <div class="cs-sponsor">
+                    Brought to you by <a class="cs-link-alternate" href="https://www.linuxmint.com">LINUX MINT</a>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/src/style/components/__index.scss
+++ b/src/style/components/__index.scss
@@ -11,3 +11,4 @@
 @import '_footer';
 @import '_form';
 @import '_profile';
+@import '_details';

--- a/src/style/components/__index.scss
+++ b/src/style/components/__index.scss
@@ -12,3 +12,4 @@
 @import '_form';
 @import '_profile';
 @import '_details';
+@import '_comments';

--- a/src/style/components/_breadcrumbs.scss
+++ b/src/style/components/_breadcrumbs.scss
@@ -1,6 +1,6 @@
 .cs-breadcrumbs {
-    opacity: .5;
     margin-bottom: 1rem;
+    opacity: .5;
 
     &:hover {
         opacity: 1;

--- a/src/style/components/_comments.scss
+++ b/src/style/components/_comments.scss
@@ -1,0 +1,47 @@
+
+.cs-comments-title {
+    margin-bottom: 1rem;
+}
+
+.cs-comment-avatar > img {
+    height: 5rem;
+    width: 5rem;
+    border-radius: .5rem;
+}
+
+.cs-comment-row {
+    margin-bottom: 3rem;
+
+    // Setting a max-width to the comments might improve readability
+    // max-width: 50rem;
+    // margin-left: auto;
+    // margin-right: auto;
+
+    &:last-child {
+        border-bottom: none;
+    }
+}
+
+.cs-comment-author {
+    margin-bottom: .5rem;
+}
+
+.cs-comment-name {
+    font-weight: bold;
+    margin-right: 1rem;
+}
+
+.cs-comment-date {
+    margin-left: 1rem;
+    color: $comment-date-color;
+}
+
+.cs-comment-form > h3,
+.cs-comment-form > form {
+    margin-bottom: .5rem;
+}
+
+.cs-comment-form > form > textarea {
+    margin-bottom: .5rem;
+    display: block;
+}

--- a/src/style/components/_details.scss
+++ b/src/style/components/_details.scss
@@ -14,6 +14,13 @@
     }
 }
 
+.cs-details-body {
+    margin: 1rem 0;
+    padding: 1rem 0;
+    border-top: 0.0625rem solid $color-silver-3;
+    border-bottom: 0.0625rem solid $color-silver-3;
+}
+
 .cs-details-head-button {
     font-size: .75rem;
     font-weight: normal;
@@ -33,6 +40,11 @@
     line-height: 1.75rem;
     padding: 0 1rem;
     text-transform: none;
+    transition-property: all;
+
+    &:hover {
+        border-color: transparent;
+    }
 }
 
 .cs-item-details-screenshot {
@@ -44,6 +56,6 @@
     background-color: $color-white;
     border: solid 1px $color-silver;
     border-radius: .5rem;
-    margin-bottom: 1rem;
     padding: 1rem;
+    margin-top: 1rem;
 }

--- a/src/style/components/_details.scss
+++ b/src/style/components/_details.scss
@@ -1,0 +1,49 @@
+.cs-details-head {
+
+    h1 {
+        font-size: 1.9rem;
+        margin-right: .5rem;
+    }
+
+    & > div {
+        & > img {
+            height: 3rem;
+            margin-right: .5rem;
+            width: 3rem;
+        }
+    }
+}
+
+.cs-details-head-button {
+    font-size: .75rem;
+    font-weight: normal;
+    height: 1.75rem;
+    line-height: 1.75rem;
+    padding: 0 1rem;
+    text-transform: none;
+}
+
+.cs-details-head-button-w {
+    background-color: transparent;
+    border: solid 1px $color-silver;
+    color: $color-black;
+    font-size: .75rem;
+    font-weight: normal;
+    height: 1.75rem;
+    line-height: 1.75rem;
+    padding: 0 1rem;
+    text-transform: none;
+}
+
+.cs-item-details-screenshot {
+    max-width: 100%;
+    width: auto;
+}
+
+.cs-item-details-description {
+    background-color: $color-white;
+    border: solid 1px $color-silver;
+    border-radius: .5rem;
+    margin-bottom: 1rem;
+    padding: 1rem;
+}

--- a/src/style/components/_header.scss
+++ b/src/style/components/_header.scss
@@ -1,15 +1,18 @@
 .cs-header {
     color: $header-color;
-    height: $header-height;
     justify-content: space-between;
     margin: auto;
     max-width: $global-max-width;
-    padding: $header-padding-vertical 0;
+    padding: $header-padding-vertical 1rem;
     width: 100%;
+
+    @media (min-width: 72rem) {
+        padding-right: 0;
+        padding-left: 0;
+    }
 }
 
 .cs-header-logo {
-    padding-top: .3125rem;
 
     img {
         display: block;
@@ -31,6 +34,7 @@
 
     a {
         color: $links-alt-color;
+        box-sizing: border-box;
     }
 
     &-link,
@@ -44,7 +48,7 @@
         color: $header-color;
         font-family: $font-roboto;
         font-size: .875rem;
-        padding: .375rem $header-link-separation-between / 2;
+        padding: 0.375rem $header-link-separation-between / 3;
         text-decoration: none;
         text-transform: uppercase;
         vertical-align: middle;

--- a/src/style/components/_items-list.scss
+++ b/src/style/components/_items-list.scss
@@ -43,8 +43,8 @@ a {
         width: 17.1875rem;
 
         & > img {
-            max-height: 3rem;
-            max-width: 3rem;
+            height: 3rem;
+            width: 3rem;
         }
 
         & > label {

--- a/src/style/components/_jumbotron.scss
+++ b/src/style/components/_jumbotron.scss
@@ -12,7 +12,7 @@
     margin: auto;
     max-width: $global-max-width;
     min-height: 26.5rem;
-    padding-bottom: 2rem;
+    padding: 2rem 1rem;
     width: 100%;
 
     p {
@@ -22,6 +22,11 @@
         line-height: 1.5;
         margin: 1rem 0 1.5rem;
         max-width: 32.5rem;
+    }
+
+    @media (min-width: 72rem) {
+        padding-right: 0;
+        padding-left: 0;
     }
 }
 

--- a/src/style/components/_main-wrap.scss
+++ b/src/style/components/_main-wrap.scss
@@ -1,8 +1,13 @@
 .cs-main-wrap {
     margin: auto;
     max-width: $global-max-width;
-    padding: $global-padding 0;
+    padding: $global-padding 1rem;
     width: 100%;
+
+    @media (min-width: 72rem) {
+        padding-right: 0;
+        padding-left: 0;
+    }
 }
 
 

--- a/src/style/generic/_global.scss
+++ b/src/style/generic/_global.scss
@@ -7,11 +7,11 @@ body {
 
 body {
     min-height: 100vh;
-    overflow-x: hidden;
+    //overflow-x: hidden;
     overflow-y: scroll;
 }
 
 * {
-    //box-sizing: border-box;
+    box-sizing: border-box;
     font-family: $font-open-sans;
 }

--- a/src/style/objects/_flex.scss
+++ b/src/style/objects/_flex.scss
@@ -24,3 +24,7 @@
 .cs-flex-grow {
     flex-grow: 1;
 }
+
+.cs-flex-wrap {
+    flex-wrap: wrap;
+}

--- a/src/style/settings/_variables.scss
+++ b/src/style/settings/_variables.scss
@@ -15,7 +15,7 @@ $links-alt-hover: $primary-color;
 
 // Header
 $header-color: $color-white;
-$header-padding-vertical: $global-padding;
+$header-padding-vertical: ($global-padding * 1.25);
 $header-height: 2.25rem;
 $header-subtitle-color: $color-off-white-2;
 $header-link-separation-between: 1.75rem;
@@ -59,6 +59,10 @@ $spotlight-header-color: $primary-color-dark;
 $spotlight-item-header-color: $primary-color;
 $spotlight-item-description-color: $color-silver-3;
 $spotlight-item-publish-color: $color-silver-2;
+
+// Comments
+$comment-date-color: $color-silver;
+
 
 // Footer
 $footer-bg-color: $color-black;

--- a/src/style/trumps/_jumbotron.scss
+++ b/src/style/trumps/_jumbotron.scss
@@ -1,13 +1,13 @@
-.cs-jumbotron-index {
-    justify-content: top;
-    min-height: 22rem;
-    padding: 2rem 0 4.5rem;
-    width: 100%;
-
-    p {
-        margin: 1.25rem 0 2.125rem;
-    }
-}
+// .cs-jumbotron-index {
+//     justify-content: top;
+//     min-height: 22rem;
+//     padding: 2rem 0 4.5rem;
+//     width: 100%;
+//
+//     p {
+//         margin: 1.25rem 0 2.125rem;
+//     }
+// }
 
 .cs-jumbotron-small {
     background: $brand-color-darker;


### PR DESCRIPTION
First commit is old stuff already applied to spices master.

second commit fixes a few things
1. takes in-lined comment style and puts them in the stylesheet.
2. add left/right padding when window is < 70rem wide. 
3. removes overflow-x to body, temp fix for https://github.com/clefebvre/cinnamon-spices/issues/12
4. applies box-sizing: border-box to fix a bunch of screwed up paddings.

